### PR TITLE
fix: update store file to use current directory instead of parent directory

### DIFF
--- a/src/store.py
+++ b/src/store.py
@@ -6,7 +6,7 @@ from logger import Logger
 
 class Store:
     MAPPING_FILENAME = "challenge_issues.json"
-    MAPPING_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), MAPPING_FILENAME)
+    MAPPING_PATH = os.path.join(os.path.dirname(__file__), MAPPING_FILENAME)
     _lock = threading.Lock()
     _logger: Logger | None = None
     


### PR DESCRIPTION
This update fixes #20 by updating the store file location from the same directory, to the parent directory, which was introduced by mistake in 27085b4.

This does cause a breaking change to the current version, and all users are expected to update their deployment to use the current directory (the current configuration in the `docker-compose.yml` files provided).
If you have not update the `docker-compose.yml` files, you should take a copy of the `/challenge_issues.json`, and store it in the `/app/challenge_issues.json` before stopping the container. If the data stored in `/challenge_issues.json` is not backed up before updating, data loss may occur.